### PR TITLE
Add Cursor KZ AI community

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 
 🇰🇿 Focused on Kazakhstan's IT ecosystem — from programming languages and DevOps to startups and job postings.
 
-**40** groups · **18** channels · **5** bots
+**41** groups · **18** channels · **5** bots
 
 ## Contents
 
 - [Groups](#groups)
+  - [AI](#ai)
   - [Data & Analytics](#data--analytics)
   - [DevOps & SysAdmin](#devops--sysadmin)
   - [Game Development](#game-development)
@@ -29,6 +30,10 @@
 - [Contributing](#contributing)
 
 ## Groups
+
+### AI
+
+- [Cursor Kazakhstan / AI Community](https://t.me/cursor_kz) `167` - Cursor and AI coding community in Kazakhstan
 
 ### Data & Analytics
 

--- a/data/communities.json
+++ b/data/communities.json
@@ -2,7 +2,7 @@
   "meta": {
     "title": "Awesome Kazakhstan IT Telegram",
     "description": "A curated list of IT-related Telegram groups, channels, and bots for the Kazakhstan tech community",
-    "last_updated": "2026-01-30",
+    "last_updated": "2026-06-17",
     "source_repo": "https://github.com/saubakirov/KZ-IT-telegram-list"
   },
   "groups": [
@@ -41,6 +41,15 @@
       "category": "general",
       "last_verified": "2026-01-30",
       "member_count": 1313
+    },
+    {
+      "name": "Cursor Kazakhstan / AI Community",
+      "handle": "cursor_kz",
+      "description": "Cursor and AI coding community in Kazakhstan",
+      "description_ru": "Сообщество пользователей Cursor и AI-инструментов в Казахстане",
+      "category": "ai",
+      "last_verified": "2026-06-17",
+      "member_count": 167
     },
     {
       "name": "Automation KZ",
@@ -570,6 +579,7 @@
     }
   ],
   "categories": {
+    "ai": "AI",
     "programming-languages": "Programming Languages",
     "web-development": "Web Development",
     "mobile": "Mobile Development",


### PR DESCRIPTION
## Summary

- Add a new `AI` group category to the generated list.
- Add `Cursor Kazakhstan / AI Community` (`@cursor_kz`) under `Groups -> AI`.
- Regenerate `README.md` from `data/communities.json`.

## Validation

- `python3 scripts/validate_schema.py`
- `python3 scripts/validate_links.py`
- `python3 scripts/generate_readme.py`
